### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Educom Web SMS
-Send SMS via the Educom web interface with a little Python script.
+# Educom/XOXO Web SMS
+Send SMS via the ~~Educom~~ XOXO web interface with a little Python script.
 
 ## Usage
 ```
 EducomWebSms.py [-h] username password prefix number message
 
-Send a SMS via your Educom Web SMS account.
+Send a SMS via your XOXO Web SMS account.
 
 positional arguments:
   username    Username (mail or phone number).
@@ -17,3 +17,5 @@ positional arguments:
 optional arguments:
   -h, --help  show this help message and exit
 ```
+
+**Important**: This works for Educom customers who signed up 2021 and earlier. All 2022 and later Educom constracts do not work.


### PR DESCRIPTION
Educom heißt jetzt XOXO. Das neue Educom ist im Netz von 3 und verwendet daher keinen Kontomanager mehr. Der Kontomanager von XOXO ist momentan aber noch weiterhin unter educom.kontomanager.at erreichbar, allerdings auch unter der neuen Domain xoxo.kontomanager.at. Eventuall wird educom-Domain einmal entfernt werden, das müsste man dann auch im Skript ergänzen.